### PR TITLE
Fix GetDeviceByName baseURL handling

### DIFF
--- a/cmd/forward.go
+++ b/cmd/forward.go
@@ -97,7 +97,7 @@ func (o *forwardOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	home := filepath.Dir(o.ApiTokenFile)
-	remoteID, err := portierapi.GetDeviceByName(home, strings.TrimSuffix(o.ApiURL, "/api"), remoteName)
+	remoteID, err := portierapi.GetDeviceByName(home, o.ApiURL, remoteName)
 	if err != nil {
 		return err
 	}

--- a/internal/portier/api/device_by_name.go
+++ b/internal/portier/api/device_by_name.go
@@ -15,6 +15,8 @@ type DeviceByNameResponse struct {
 }
 
 // GetDeviceByName fetches the device GUID for a given device name from the API.
+// The baseURL should include the `/api` suffix. When an API key is used, the
+// function will automatically trim `/api` to access the spider endpoint.
 func GetDeviceByName(home, baseURL, name string) (string, error) {
 	accessToken, err := LoadAccessToken(home)
 	useAPIKey := false
@@ -34,7 +36,7 @@ func GetDeviceByName(home, baseURL, name string) (string, error) {
 	baseURL = strings.TrimSuffix(baseURL, "/")
 	var url string
 	if useAPIKey {
-		url = fmt.Sprintf("%s/spider/deviceByName/%s", baseURL, name)
+		url = fmt.Sprintf("%s/spider/deviceByName/%s", strings.TrimSuffix(baseURL, "/api"), name)
 	} else {
 		url = fmt.Sprintf("%s/deviceByName/%s", baseURL, name)
 	}


### PR DESCRIPTION
## Summary
- use the API URL consistently when looking up a device
- trim `/api` inside `GetDeviceByName` when needed

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68888c7073a083238e725f4e4cda6e7d